### PR TITLE
Replaced `member` to `recipient` to be explicit.

### DIFF
--- a/Slack_Guidelines_En.md
+++ b/Slack_Guidelines_En.md
@@ -17,7 +17,7 @@ We use Slack as our company-wide communication tool in Mercari. The purpose of t
     - Specific external people
 - Mentions
     - Before mentioning @here/@channel in channels with many people, consider whether or not it’s needed.
-    - It is the members' responsibility to adjust mention settings for evenings, weekends, etc. 
+    - It is the recipient's responsibility to adjust mention settings for evenings, weekends, etc. 
 - Channels
     - Anyone can make a channel
     - Please be sure to write the purpose when creating a new channel


### PR DESCRIPTION
Hi, @helosshi and @jollyjoester.
The PR guideline says the IT service team maintains this repository and everyone tags jollyjoester so I tagged you all. Thanks.

These is just minor changes but I'd like to be explicit about who the member is. 
The Japanese version says about `member` as `受け取り側` so I tried to align the English version with it.
